### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Check if the progress view spin animation is active.
 
 Simply add the following lines to your `Podfile`:
 ```ruby
-# required by Cocoapods 0.36.0.rc.1 for Swift Pods
+# required by CocoaPods 0.36.0.rc.1 for Swift Pods
 use_frameworks! 
 
 pod 'ABCircularProgressView', '~> 1.0'
@@ -105,7 +105,7 @@ pod 'ABCircularProgressView', '~> 1.0'
 - [x] Playground example
 - [x] Project example
 - [x] Add spin progress
-- [x] Cocoapods support
+- [x] CocoaPods support
 
 ##Contact
 Mail me at [adil.benmoussa@gmal.com](adil.benmoussa@gmal.com)


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
